### PR TITLE
Use the new Pex_Fingerprint_* functions instead of the *_For_Types ones

### DIFF
--- a/fingerprint.go
+++ b/fingerprint.go
@@ -85,7 +85,7 @@ func newFingerprint(input []byte, isFile bool, typ FingerprintType) (*Fingerprin
 		cFile := C.CString(string(input))
 		defer C.free(unsafe.Pointer(cFile))
 
-		C.Pex_Fingerprint_File_For_Types(cFile, ft, status, C.int(typ))
+		C.Pex_Fingerprint_File(cFile, ft, status, C.int(typ))
 	} else {
 		buf := C.Pex_Buffer_New()
 		if buf == nil {
@@ -97,7 +97,7 @@ func newFingerprint(input []byte, isFile bool, typ FingerprintType) (*Fingerprin
 		size := C.size_t(len(input))
 
 		C.Pex_Buffer_Set(buf, data, size)
-		C.Pex_Fingerprint_Buffer_For_Types(buf, ft, status, C.int(typ))
+		C.Pex_Fingerprint_Buffer(buf, ft, status, C.int(typ))
 	}
 
 	if err := statusToError(status); err != nil {


### PR DESCRIPTION
Previously we had e.g. Pex_Fingerprint_File and
Pex_Fingerprint_File_For_Types functions and since Pex_Fingerprint_File was unused we replaced it's implementation with the one from *_For_Types and got rid of that one.