### PR TITLE
Allow specifying different PexSearch types

### DIFF
--- a/000init.go
+++ b/000init.go
@@ -8,7 +8,7 @@ package pex
 // #cgo LDFLAGS: -Wl,-rpath,/usr/local/lib
 //
 // #define PEX_SDK_MAJOR_VERSION 4
-// #define PEX_SDK_MINOR_VERSION 0
+// #define PEX_SDK_MINOR_VERSION 1
 //
 // #include <pex/sdk/version.h>
 import "C"


### PR DESCRIPTION
These include:

* **IdentifyMusic:** return assets that will help identify the music within the media file
* **FindMatches:** return all assets that matched the provided media file

Example usage:

```go
fut, err := client.StartSearch(&pex.PexSearchRequest{
  Fingerprint: ft,
  Type:        pex.FindMatches,
})
```